### PR TITLE
[PR] 화면 값 전달 로직, 이메일 인증 로직

### DIFF
--- a/Tteolione.xcodeproj/project.pbxproj
+++ b/Tteolione.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		72361E752D0EB575009BEF12 /* SignUpProfileImageRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72361E742D0EB575009BEF12 /* SignUpProfileImageRequestBody.swift */; };
 		72361E782D0EB691009BEF12 /* MultipartFormDataConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72361E772D0EB691009BEF12 /* MultipartFormDataConvertible.swift */; };
 		72361E7B2D0EC866009BEF12 /* HeaderKeyAndValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72361E7A2D0EC866009BEF12 /* HeaderKeyAndValue.swift */; };
+		72361E7D2D12B7BC009BEF12 /* SignUpReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72361E7C2D12B7BC009BEF12 /* SignUpReactor.swift */; };
+		72361E802D12BFAC009BEF12 /* SignUpMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72361E7F2D12BFAC009BEF12 /* SignUpMediator.swift */; };
+		72361E832D12BFDF009BEF12 /* DefaultSignUpMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72361E822D12BFDF009BEF12 /* DefaultSignUpMediator.swift */; };
 		724DEC6F2D0091B700171F44 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724DEC6E2D0091B700171F44 /* AppDelegate.swift */; };
 		724DEC712D0091B700171F44 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724DEC702D0091B700171F44 /* SceneDelegate.swift */; };
 		724DEC782D0091B800171F44 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 724DEC772D0091B800171F44 /* Assets.xcassets */; };
@@ -115,6 +118,9 @@
 		72361E742D0EB575009BEF12 /* SignUpProfileImageRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpProfileImageRequestBody.swift; sourceTree = "<group>"; };
 		72361E772D0EB691009BEF12 /* MultipartFormDataConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataConvertible.swift; sourceTree = "<group>"; };
 		72361E7A2D0EC866009BEF12 /* HeaderKeyAndValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderKeyAndValue.swift; sourceTree = "<group>"; };
+		72361E7C2D12B7BC009BEF12 /* SignUpReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpReactor.swift; sourceTree = "<group>"; };
+		72361E7F2D12BFAC009BEF12 /* SignUpMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpMediator.swift; sourceTree = "<group>"; };
+		72361E822D12BFDF009BEF12 /* DefaultSignUpMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSignUpMediator.swift; sourceTree = "<group>"; };
 		724DEC6B2D0091B700171F44 /* Tteolione.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tteolione.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		724DEC6E2D0091B700171F44 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		724DEC702D0091B700171F44 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -306,6 +312,22 @@
 			path = Header;
 			sourceTree = "<group>";
 		};
+		72361E7E2D12BFA0009BEF12 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				72361E7F2D12BFAC009BEF12 /* SignUpMediator.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		72361E812D12BFBC009BEF12 /* Mediator */ = {
+			isa = PBXGroup;
+			children = (
+				72361E822D12BFDF009BEF12 /* DefaultSignUpMediator.swift */,
+			);
+			path = Mediator;
+			sourceTree = "<group>";
+		};
 		724DEC622D0091B700171F44 = {
 			isa = PBXGroup;
 			children = (
@@ -482,6 +504,8 @@
 		724DECC02D02CB1600171F44 /* JoinView */ = {
 			isa = PBXGroup;
 			children = (
+				72361E812D12BFBC009BEF12 /* Mediator */,
+				72361E7E2D12BFA0009BEF12 /* Protocol */,
 				72361E2D2D042716009BEF12 /* ViewController */,
 				724DECC22D02CB2200171F44 /* View */,
 				724DECC12D02CB1C00171F44 /* Reactor */,
@@ -493,6 +517,7 @@
 		724DECC12D02CB1C00171F44 /* Reactor */ = {
 			isa = PBXGroup;
 			children = (
+				72361E7C2D12B7BC009BEF12 /* SignUpReactor.swift */,
 				724DECC72D02CBE400171F44 /* EmailAuthReactor.swift */,
 				72361E322D0427F7009BEF12 /* AuthNumReactor.swift */,
 				72361E3B2D087BA2009BEF12 /* IDReactor.swift */,
@@ -636,6 +661,7 @@
 				72361E202D02D18F009BEF12 /* JoinImageView.swift in Sources */,
 				72361E732D0EA96F009BEF12 /* JoinRequestBody.swift in Sources */,
 				72361E1D2D02D095009BEF12 /* TopBarView.swift in Sources */,
+				72361E832D12BFDF009BEF12 /* DefaultSignUpMediator.swift in Sources */,
 				724DEC992D01734200171F44 /* BaseViewController.swift in Sources */,
 				724DECA42D01835100171F44 /* LoginReactor.swift in Sources */,
 				72361E3C2D087BA2009BEF12 /* IDReactor.swift in Sources */,
@@ -644,11 +670,13 @@
 				724DEC712D0091B700171F44 /* SceneDelegate.swift in Sources */,
 				724DECA82D0184A700171F44 /* LoginView.swift in Sources */,
 				72361E3A2D087B82009BEF12 /* IDViewController.swift in Sources */,
+				72361E7D2D12B7BC009BEF12 /* SignUpReactor.swift in Sources */,
 				72361E662D0C2D30009BEF12 /* NetworkProvider.swift in Sources */,
 				72361E312D0427CC009BEF12 /* AuthNumView.swift in Sources */,
 				724DEC9C2D01746A00171F44 /* ResourceFonts.swift in Sources */,
 				72361E4E2D0BEEC5009BEF12 /* NicknameView.swift in Sources */,
 				724DECAF2D01870800171F44 /* CommonTextField.swift in Sources */,
+				72361E802D12BFAC009BEF12 /* SignUpMediator.swift in Sources */,
 				72361E682D0C2DFC009BEF12 /* JoinAPI.swift in Sources */,
 				72361E3E2D0B1754009BEF12 /* PasswordViewController.swift in Sources */,
 				72361E262D02D208009BEF12 /* AppTextFieldPlaceholder.swift in Sources */,

--- a/Tteolione/Sources/Extension/ViewController+Extension.swift
+++ b/Tteolione/Sources/Extension/ViewController+Extension.swift
@@ -14,6 +14,12 @@ extension UIViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
     
+    func navigateToScreen<T: UIViewController>(_ viewControllerType: T.Type, reactor: (T) -> Void) {
+        let viewController = viewControllerType.init()
+        reactor(viewController)
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
     func showAlert(title: String? = nil,
                    message: String,
                    completion: (() -> Void)? = nil) {

--- a/Tteolione/Sources/Network/Provider/NetworkProvider.swift
+++ b/Tteolione/Sources/Network/Provider/NetworkProvider.swift
@@ -26,7 +26,6 @@ final class NetworkProvider<T: TargetType> {
                                retryCount: Int = 1) -> Single<R> {
         return provider.rx
             .request(target)
-            .filterSuccessfulStatusCodes()
             .map(R.self)
             .retry(retryCount)
             .catch { error in

--- a/Tteolione/Sources/Scenes/JoinView/Mediator/DefaultSignUpMediator.swift
+++ b/Tteolione/Sources/Scenes/JoinView/Mediator/DefaultSignUpMediator.swift
@@ -1,0 +1,26 @@
+//
+//  DefaultSignUpMediator.swift
+//  Tteolione
+//
+//  Created by 전준영 on 12/18/24.
+//
+
+import Foundation
+
+final class DefaultSignUpMediator: SignUpMediator {
+    
+    private let signUpReactor: SignUpReactor
+
+    init(signUpReactor: SignUpReactor) {
+        self.signUpReactor = signUpReactor
+    }
+
+    func update<T>(_ value: T, action: (T) -> SignUpReactor.Action) {
+        let reactorAction = action(value)
+        self.signUpReactor.action.onNext(reactorAction)
+    }
+
+    func get<T>(_ keyPath: KeyPath<SignUpReactor.State, T>) -> T {
+        return signUpReactor.currentState[keyPath: keyPath]
+    }
+}

--- a/Tteolione/Sources/Scenes/JoinView/Protocol/SignUpMediator.swift
+++ b/Tteolione/Sources/Scenes/JoinView/Protocol/SignUpMediator.swift
@@ -1,0 +1,13 @@
+//
+//  SignUpMediator.swift
+//  Tteolione
+//
+//  Created by 전준영 on 12/18/24.
+//
+
+import Foundation
+
+protocol SignUpMediator {
+    func update<T>(_ value: T, action: (T) -> SignUpReactor.Action)
+    func get<T>(_ keyPath: KeyPath<SignUpReactor.State, T>) -> T
+}

--- a/Tteolione/Sources/Scenes/JoinView/Reactor/EmailAuthReactor.swift
+++ b/Tteolione/Sources/Scenes/JoinView/Reactor/EmailAuthReactor.swift
@@ -29,13 +29,17 @@ final class EmailAuthReactor: Reactor {
         var errorMessage: String?
     }
     
+    let networkProvider: NetworkProvider<JoinAPI>
+    let mediator: SignUpMediator
+    
     let initialState: State = State()
     let backNavigation = PublishSubject<Void>()
     let navigateToNextView = PublishSubject<Void>()
-    private let networkProvider: NetworkProvider<JoinAPI>
     
-    init(networkProvider: NetworkProvider<JoinAPI>) {
+    init(networkProvider: NetworkProvider<JoinAPI>,
+         mediator: SignUpMediator) {
         self.networkProvider = networkProvider
+        self.mediator = mediator
     }
     
 }
@@ -58,8 +62,10 @@ extension EmailAuthReactor {
             
         case .emailCheckButtonTap:
             guard currentState.isButtonEnabled else { return .empty() }
+            let email = currentState.email
+            mediator.update(email, action: SignUpReactor.Action.updateEmail)
             return .concat([
-                performEmailCheck(email: currentState.email)
+                performEmailCheck(email: email)
             ])
         }
     }

--- a/Tteolione/Sources/Scenes/JoinView/Reactor/SignUpReactor.swift
+++ b/Tteolione/Sources/Scenes/JoinView/Reactor/SignUpReactor.swift
@@ -1,0 +1,72 @@
+//
+//  SignUpReactor.swift
+//  Tteolione
+//
+//  Created by 전준영 on 12/18/24.
+//
+
+import Foundation
+import ReactorKit
+import RxSwift
+
+final class SignUpReactor: Reactor {
+    
+    enum Action {
+        case updateEmail(String)
+        case updateAuthCode(String)
+        case updatePassword(String)
+    }
+    
+    enum Mutation {
+        case setEmail(String)
+        case setAuthCode(String)
+        case setPassword(String)
+    }
+    
+    struct State {
+        var email: String = ""
+        var authCode: String = ""
+        var password: String = ""
+    }
+    
+    let initialState = State()
+    
+}
+
+extension SignUpReactor {
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case let .updateEmail(email):
+            return .just(.setEmail(email))
+            
+        case let .updateAuthCode(authCode):
+            return .just(.setAuthCode(authCode))
+            
+        case let .updatePassword(password):
+            return .just(.setPassword(password))
+        }
+    }
+    
+}
+
+extension SignUpReactor {
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+        case let .setEmail(email):
+            newState.email = email
+            
+        case let .setAuthCode(authCode):
+            newState.authCode = authCode
+            
+        case let .setPassword(password):
+            newState.password = password
+        }
+        
+        return newState
+    }
+    
+}

--- a/Tteolione/Sources/Scenes/JoinView/ViewController/AuthNumViewController.swift
+++ b/Tteolione/Sources/Scenes/JoinView/ViewController/AuthNumViewController.swift
@@ -15,7 +15,6 @@ final class AuthNumViewController: BaseViewController<AuthNumView> {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.reactor = AuthNumReactor()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Tteolione/Sources/Scenes/JoinView/ViewController/EmailAuthViewController.swift
+++ b/Tteolione/Sources/Scenes/JoinView/ViewController/EmailAuthViewController.swift
@@ -15,7 +15,10 @@ final class EmailAuthViewController: BaseViewController<EmailAuthView> {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.reactor = EmailAuthReactor(networkProvider: NetworkProvider<JoinAPI>())
+        self.reactor = EmailAuthReactor(
+            networkProvider: NetworkProvider<JoinAPI>(),
+            mediator: DefaultSignUpMediator(signUpReactor: SignUpReactor())
+        )
     }
     
 }
@@ -76,7 +79,12 @@ extension EmailAuthViewController: View {
         reactor.navigateToNextView
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, _ in
-                owner.navigateToScreen(AuthNumViewController())
+                owner.navigateToScreen(AuthNumViewController.self) { viewController in
+                    viewController.reactor = AuthNumReactor(
+                        networkProvider: owner.reactor?.networkProvider ?? NetworkProvider<JoinAPI>(),
+                        mediator: reactor.mediator
+                    )
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/Tteolione/Sources/Scenes/JoinView/ViewController/EmailAuthViewController.swift
+++ b/Tteolione/Sources/Scenes/JoinView/ViewController/EmailAuthViewController.swift
@@ -56,6 +56,7 @@ extension EmailAuthViewController: View {
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.errorMessage }
+            .distinctUntilChanged()
             .compactMap { $0 }
             .observe(on: MainScheduler.instance)
             .bind(with: self) { owner, errorMessage in


### PR DESCRIPTION
# 주요내용
- 화면 값 전달 로직 추가
    - 화면 값 전달을 위해 Mediator 추가 
        - Mediator로 회원가입 화면마다 전달할 공통 SignUpReactor 중재자 역할 추가
    - 화면 push 함수 추가
- 이메일 인증 로직 추가
- 알림창 안뜨는 상황 수정
    - 200~299만 받는 경우 수정
    - 알림창 중복 방지
